### PR TITLE
fix `transform-selections-to-uppercase` command not appearing and `transform-selections-to-lowercase` behaving incorrectly

### DIFF
--- a/src/commands/transform-selections-to-uppercase.ts
+++ b/src/commands/transform-selections-to-uppercase.ts
@@ -5,8 +5,8 @@ import SelectionsProcessing from "../classes/SelectionsProcessing";
 
 export const transformSelectionsToUppercase: KeyshotsCommand = {
     category: Category.REPLACE_SELECTIONS,
-    id: 'transform-selections-to-lowercase',
-    name: "Transform selections to lowercase",
+    id: 'transform-selections-to-uppercase',
+    name: "Transform selections to uppercase",
     hotkeys: {
         keyshots: [HotKey("U", "Alt")],
         visual_studio: [HotKey("U", "Mod", "Shift")],


### PR DESCRIPTION
I believe this fixes #22.

The `Transform selections to uppercase` and `Transform selections to lowercase` were both sharing the same ID and name.

I've corrected the name and ID of the `Transform selections to uppercase` command back to what it should be.

## demo of it working

[fixed uppercase command.webm](https://github.com/user-attachments/assets/14b46791-0e6d-4c1b-b1ee-b32b31f642e3)
